### PR TITLE
[FEATURE] 시큐리티 기본 설정정보 추가

### DIFF
--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -15,16 +15,20 @@ public class JwtSecurityConfiguration {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http
-                .csrf().disable()
-                .formLogin().disable()
-                .httpBasic().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .authorizeHttpRequests()
-                .requestMatchers(PUBLIC_END_POINT).permitAll()
-                .anyRequest().authenticated()
-                .and()
-                .build();
+        /*
+         * REST API 서버를 기반으로 하기 때문에 CSRF 필터 해제, 폼 로그인 사용 X
+         * JWT 토큰 기반의 인증, 인가를 위해 HTTP Basic 인증 사용 X, 세션 생성 및 사용 X
+         */
+        http.csrf().disable()
+            .formLogin().disable()
+            .httpBasic().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        // 인가 API
+        http.authorizeHttpRequests()
+            .requestMatchers(PUBLIC_END_POINT).permitAll()
+            .anyRequest().authenticated();
+
+        return http.build();
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -1,0 +1,30 @@
+package io.github.cokelee777.springsecurityjwtauth.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class JwtSecurityConfiguration {
+
+    private static final String[] PUBLIC_END_POINT = {"/", "/sign-in/**", "/sign-up/**", "/error"};
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf().disable()
+                .formLogin().disable()
+                .httpBasic().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests()
+                .requestMatchers(PUBLIC_END_POINT).permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .build();
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -11,7 +11,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class JwtSecurityConfiguration {
 
-    private static final String[] PUBLIC_END_POINT = {"/", "/sign-in/**", "/sign-up/**", "/error"};
+    private static final String[] PUBLIC_END_POINT = {"/", "/sign-in", "/sign-up", "/error"};
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
## 제목

스프링 시큐리티를 사용하여 인증 및 인가를 하기 위해서 JWT를 사용하기 위한 기본 시큐리티 구성

## 작업 내용

1. CSRF 공격을 예방하기 위한 필터 해제

기본적으로 REST API 기반의 서버를 보통 만들기 때문에 Stateless(상태를 유지하지 않는)하다. 하지만 CSRF는 웹에 대해 요청할 때 보통 발생한다. 이런 구조는 보통 템플릿 엔진(Thymeleaf, JSP)등을 사용하여 서버 측에서 전체 HTML을 생성하는 구조이다.

따라서 REST API의 조건에는 더 이상 CSRF가 관련이 없어서 필터를 해제하였다. 또한 액세스 토큰을 발급받기 위한 JWT Refresh Token은 Http Only Cookie를 사용해서 스크립트가 데이터에 접근하는 것을 방지하게 처리할 예정이다.

2. 폼 로그인을 인증 방식 미사용

REST API 기반의 로그인 방식을 채택하였기 때문에 폼 로그인 인증 방식을 해제

3. 세션 정책 - Stateless

스프링 시큐리티가 인증에 성공해도 세션에 사용자 정보를 저장하지 않도록 하고, 시큐리티 컨텍스트에도 저장하지 않도록 했다. 

-> JWT 기반의 인증 및 인가 방식을 사용할 것이기 때문

4. 인가

모든 사용자가 접근할 수 있는 페이지는 홈 화면, 로그인, 회원가입, 기본 에러 페이지를 열어두고, 나머지 페이지 요청에는 인증이 필요하도록 구현

기본 에러 페이지는 일단 열어두고 나중에 에러 핸들러를 구현 예정