### PR TITLE
[FEATURE]  회원가입 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.6'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.6'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+//    compileOnly 'org.projectlombok:lombok'
+//    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/SpringSecurityJwtAuthApplication.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/SpringSecurityJwtAuthApplication.java
@@ -1,7 +1,12 @@
 package io.github.cokelee777.springsecurityjwtauth;
 
+import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SpringBootApplication
 public class SpringSecurityJwtAuthApplication {
@@ -10,4 +15,9 @@ public class SpringSecurityJwtAuthApplication {
         SpringApplication.run(SpringSecurityJwtAuthApplication.class, args);
     }
 
+    // 동시성 관리를 위해 스레드 안전한 ConcurrentHashMap 사용
+    @Bean
+    public Map<String, MemoryUser> memoryStore() {
+        return new ConcurrentHashMap<>();
+    }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService memoryUserService;
+    private final UserService userService;
 
     @PostMapping("/sign-up")
     public ResponseEntity<SuccessResponseBody<Void>> signUp(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {
-        memoryUserService.createUser(signUpRequestDto);
+        userService.createUser(signUpRequestDto);
         return ResponseEntity.ok()
                 .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, null));
     }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
@@ -1,0 +1,27 @@
+package io.github.cokelee777.springsecurityjwtauth.controller;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
+import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.service.UserService;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService memoryUserService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<SuccessResponseBody<Void>> signUp(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {
+        memoryUserService.createUser(signUpRequestDto);
+        return ResponseEntity.ok()
+                .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, null));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
@@ -5,7 +5,6 @@ import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody
 import io.github.cokelee777.springsecurityjwtauth.service.UserService;
 import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,10 +12,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
 
     @PostMapping("/sign-up")
     public ResponseEntity<SuccessResponseBody<Void>> signUp(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
@@ -1,0 +1,36 @@
+package io.github.cokelee777.springsecurityjwtauth.domain;
+
+import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class MemoryUser extends User {
+
+    private String id;
+    private String identifier;
+    private String password;
+    private String nickname;
+
+    public MemoryUser(String identifier, String password, String nickname) {
+        super();
+        init(identifier, password, nickname);
+    }
+
+    public MemoryUser(String identifier, String password, String nickname, UserRole role) {
+        super(role);
+        init(identifier, password, nickname);
+    }
+
+    private void init(String identifier, String password, String nickname){
+        this.id = createUUID();
+        this.identifier = identifier;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+    private String createUUID(){
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
@@ -1,32 +1,57 @@
 package io.github.cokelee777.springsecurityjwtauth.domain;
 
 import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 
+import java.util.Objects;
 import java.util.UUID;
 
-@Getter
-@EqualsAndHashCode
 public class MemoryUser implements User {
 
-    @Builder.Default
     private final String id = createUUID();
     private final String identifier;
     private final String password;
     private final String nickname;
-    private final UserRole role;
+    private UserRole role = UserRole.USER;
 
-    @Builder
+    public MemoryUser(String identifier, String password, String nickname) {
+        this.identifier = identifier;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
     public MemoryUser(String identifier, String password, String nickname, UserRole role) {
         this.identifier = identifier;
         this.password = password;
         this.nickname = nickname;
-        this.role = (role == null) ? UserRole.USER : role;
+        this.role = role;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIdentifier() {
+        return identifier;
     }
 
     private String createUUID(){
         return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MemoryUser that = (MemoryUser) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(identifier, that.identifier) &&
+                Objects.equals(password, that.password) &&
+                Objects.equals(nickname, that.nickname) &&
+                role == that.role;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, identifier, password, nickname, role);
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
@@ -1,33 +1,29 @@
 package io.github.cokelee777.springsecurityjwtauth.domain;
 
 import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
-public class MemoryUser extends User {
+public class MemoryUser implements User {
 
-    private String id;
-    private String identifier;
-    private String password;
-    private String nickname;
+    @Builder.Default
+    private final String id = createUUID();
+    private final String identifier;
+    private final String password;
+    private final String nickname;
 
-    public MemoryUser(String identifier, String password, String nickname) {
-        super();
-        init(identifier, password, nickname);
-    }
+    @Builder.Default
+    private UserRole role = UserRole.USER;
 
+    @Builder
     public MemoryUser(String identifier, String password, String nickname, UserRole role) {
-        super(role);
-        init(identifier, password, nickname);
-    }
-
-    private void init(String identifier, String password, String nickname){
-        this.id = createUUID();
         this.identifier = identifier;
         this.password = password;
         this.nickname = nickname;
+        this.role = role;
     }
 
     private String createUUID(){

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
@@ -2,11 +2,13 @@ package io.github.cokelee777.springsecurityjwtauth.domain;
 
 import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
+@EqualsAndHashCode
 public class MemoryUser implements User {
 
     @Builder.Default
@@ -14,16 +16,14 @@ public class MemoryUser implements User {
     private final String identifier;
     private final String password;
     private final String nickname;
-
-    @Builder.Default
-    private UserRole role = UserRole.USER;
+    private final UserRole role;
 
     @Builder
     public MemoryUser(String identifier, String password, String nickname, UserRole role) {
         this.identifier = identifier;
         this.password = password;
         this.nickname = nickname;
-        this.role = role;
+        this.role = (role == null) ? UserRole.USER : role;
     }
 
     private String createUUID(){

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/User.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/User.java
@@ -1,14 +1,4 @@
 package io.github.cokelee777.springsecurityjwtauth.domain;
 
-import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-public abstract class User {
-
-    private UserRole role = UserRole.USER;
-
-    public User(UserRole role) {
-        this.role = role;
-    }
+public interface User {
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/User.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/User.java
@@ -1,0 +1,14 @@
+package io.github.cokelee777.springsecurityjwtauth.domain;
+
+import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public abstract class User {
+
+    private UserRole role = UserRole.USER;
+
+    public User(UserRole role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/SignUpRequestDto.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/SignUpRequestDto.java
@@ -18,4 +18,9 @@ public record SignUpRequestDto(
         @Nullable
         String nickname
 ) {
+
+        @Override
+        public String nickname() {
+                return (nickname != null) ? nickname : "";
+        }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/SignUpRequestDto.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/SignUpRequestDto.java
@@ -1,0 +1,21 @@
+package io.github.cokelee777.springsecurityjwtauth.dto;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignUpRequestDto(
+        @NotBlank(message = "아이디를 입력해주세요")
+        @Email(message = "이메일 형식으로 입력해주세요")
+        String identifier,
+
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}",
+                message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용해주세요")
+        String password,
+
+        @Nullable
+        String nickname
+) {
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/common/ExceptionResponseBody.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/common/ExceptionResponseBody.java
@@ -1,0 +1,8 @@
+package io.github.cokelee777.springsecurityjwtauth.dto.common;
+
+public record ExceptionResponseBody(
+        String code,
+        String message,
+        String detail
+) {
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/common/SuccessResponseBody.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/common/SuccessResponseBody.java
@@ -1,0 +1,10 @@
+package io.github.cokelee777.springsecurityjwtauth.dto.common;
+
+import jakarta.annotation.Nullable;
+
+public record SuccessResponseBody<T>(
+        String code,
+        String message,
+        @Nullable T data
+) {
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/enums/UserRole.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/enums/UserRole.java
@@ -1,0 +1,5 @@
+package io.github.cokelee777.springsecurityjwtauth.enums;
+
+public enum UserRole {
+    USER, MANAGER, ADMIN
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exception/DuplicateIdentifierException.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exception/DuplicateIdentifierException.java
@@ -1,0 +1,7 @@
+package io.github.cokelee777.springsecurityjwtauth.exception;
+
+public class DuplicateIdentifierException extends IllegalArgumentException {
+    public DuplicateIdentifierException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/CommonExceptionHandlerAdvice.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/CommonExceptionHandlerAdvice.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,6 +25,34 @@ import java.util.Optional;
 @Order(1)
 @RestControllerAdvice
 public class CommonExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("HttpMessageNotReadableException={}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponseBody(
+                                HttpStatus.BAD_REQUEST.name(),
+                                DefaultHttpMessage.BAD_REQUEST,
+                                ex.getMessage()
+                        )
+                );
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+            HttpMediaTypeNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("HttpMediaTypeNotSupportedException={}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+                .body(new ExceptionResponseBody(
+                                HttpStatus.UNSUPPORTED_MEDIA_TYPE.name(),
+                                DefaultHttpMessage.UNSUPPORTED_MEDIA_TYPE,
+                                ex.getMessage()
+                        )
+                );
+    }
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/CommonExceptionHandlerAdvice.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/CommonExceptionHandlerAdvice.java
@@ -1,0 +1,88 @@
+package io.github.cokelee777.springsecurityjwtauth.exceptionhandler;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Optional;
+
+@Slf4j
+@Order(1)
+@RestControllerAdvice
+public class CommonExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        Optional<FieldError> fieldError = Optional.ofNullable(ex.getBindingResult().getFieldError());
+
+        String message = DefaultHttpMessage.BAD_REQUEST;
+        if(fieldError.isPresent()) {
+            message = fieldError.get().getDefaultMessage();
+        }
+
+        log.error("MethodArgumentNotValidException={}", message);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponseBody(
+                        HttpStatus.BAD_REQUEST.name(),
+                        DefaultHttpMessage.BAD_REQUEST,
+                        message
+                    )
+                );
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("HttpRequestMethodNotSupportedException={}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(new ExceptionResponseBody(
+                        HttpStatus.METHOD_NOT_ALLOWED.name(),
+                        DefaultHttpMessage.METHOD_NOT_ALLOWED,
+                        ex.getMessage()
+                    )
+                );
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(
+            NoHandlerFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.error("NoHandlerFoundException={}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ExceptionResponseBody(
+                        HttpStatus.NOT_FOUND.name(),
+                        DefaultHttpMessage.NOT_FOUND,
+                        ex.getMessage()
+                    )
+                );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponseBody> exceptionHandler(Exception ex) {
+        log.error("Exception={}", ex.getMessage());
+        return ResponseEntity
+                .internalServerError()
+                .body(new ExceptionResponseBody(
+                        HttpStatus.INTERNAL_SERVER_ERROR.name(),
+                        DefaultHttpMessage.INTERNAL_SERVER_ERROR,
+                        ex.getMessage()
+                    )
+                );
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/CommonExceptionHandlerAdvice.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/CommonExceptionHandlerAdvice.java
@@ -2,7 +2,8 @@ package io.github.cokelee777.springsecurityjwtauth.exceptionhandler;
 
 import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
 import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -21,10 +22,11 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 import java.util.Optional;
 
-@Slf4j
 @Order(1)
 @RestControllerAdvice
 public class CommonExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/UserExceptionHandlerAdvice.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/UserExceptionHandlerAdvice.java
@@ -3,17 +3,19 @@ package io.github.cokelee777.springsecurityjwtauth.exceptionhandler;
 import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
 import io.github.cokelee777.springsecurityjwtauth.exception.DuplicateIdentifierException;
 import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Slf4j
 @Order(0)
 @RestControllerAdvice
 public class UserExceptionHandlerAdvice {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @ExceptionHandler(DuplicateIdentifierException.class)
     public ResponseEntity<ExceptionResponseBody> exceptionHandler(DuplicateIdentifierException exception) {

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/UserExceptionHandlerAdvice.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exceptionhandler/UserExceptionHandlerAdvice.java
@@ -1,0 +1,30 @@
+package io.github.cokelee777.springsecurityjwtauth.exceptionhandler;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.exception.DuplicateIdentifierException;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Order(0)
+@RestControllerAdvice
+public class UserExceptionHandlerAdvice {
+
+    @ExceptionHandler(DuplicateIdentifierException.class)
+    public ResponseEntity<ExceptionResponseBody> exceptionHandler(DuplicateIdentifierException exception) {
+        log.error("DuplicateIdentifierException={}", exception.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ExceptionResponseBody(
+                        HttpStatus.CONFLICT.name(),
+                        DefaultHttpMessage.CONFLICT,
+                        exception.getMessage()
+                    )
+                );
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
@@ -1,11 +1,13 @@
 package io.github.cokelee777.springsecurityjwtauth.repository;
 
 import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Primary
 @Repository
 public class MemoryUserRepository implements UserRepository<MemoryUser> {
 

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
@@ -1,27 +1,27 @@
 package io.github.cokelee777.springsecurityjwtauth.repository;
 
 import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Primary
 @Repository
+@RequiredArgsConstructor
 public class MemoryUserRepository implements UserRepository<MemoryUser> {
 
-    // 동시성 관리를 위해 스레드 안전한 ConcurrentHashMap 사용
-    private static final Map<String, MemoryUser> store = new ConcurrentHashMap<>();
+    private final Map<String, MemoryUser> memoryStore;
 
     @Override
     public void save(MemoryUser user) {
-        store.put(user.getId(), user);
+        memoryStore.putIfAbsent(user.getId(), user);
     }
 
     @Override
     public boolean existsByIdentifier(String identifier) {
-        return store.values().stream()
+        return memoryStore.values().stream()
                 .anyMatch(user -> user.getIdentifier().equals(identifier));
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
@@ -1,0 +1,25 @@
+package io.github.cokelee777.springsecurityjwtauth.repository;
+
+import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class MemoryUserRepository implements UserRepository<MemoryUser> {
+
+    // 동시성 관리를 위해 스레드 안전한 ConcurrentHashMap 사용
+    private static final Map<String, MemoryUser> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(MemoryUser user) {
+        store.put(user.getId(), user);
+    }
+
+    @Override
+    public boolean existsByIdentifier(String identifier) {
+        return store.values().stream()
+                .anyMatch(user -> user.getIdentifier().equals(identifier));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepository.java
@@ -1,7 +1,6 @@
 package io.github.cokelee777.springsecurityjwtauth.repository;
 
 import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
@@ -9,10 +8,13 @@ import java.util.Map;
 
 @Primary
 @Repository
-@RequiredArgsConstructor
 public class MemoryUserRepository implements UserRepository<MemoryUser> {
 
     private final Map<String, MemoryUser> memoryStore;
+
+    public MemoryUserRepository(Map<String, MemoryUser> memoryStore) {
+        this.memoryStore = memoryStore;
+    }
 
     @Override
     public void save(MemoryUser user) {

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/UserRepository.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package io.github.cokelee777.springsecurityjwtauth.repository;
+
+import io.github.cokelee777.springsecurityjwtauth.domain.User;
+
+public interface UserRepository<T extends User> {
+    void save(T user);
+
+    boolean existsByIdentifier(String identifier);
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
@@ -4,16 +4,18 @@ import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
 import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
 import io.github.cokelee777.springsecurityjwtauth.exception.DuplicateIdentifierException;
 import io.github.cokelee777.springsecurityjwtauth.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 @Primary
 @Service
-@RequiredArgsConstructor
 public class MemoryUserService implements UserService {
 
     private final UserRepository<MemoryUser> userRepository;
+
+    public MemoryUserService(UserRepository<MemoryUser> userRepository) {
+        this.userRepository = userRepository;
+    }
 
     @Override
     public void createUser(SignUpRequestDto signUpRequestDto) {
@@ -22,11 +24,11 @@ public class MemoryUserService implements UserService {
             throw new DuplicateIdentifierException("중복된 아이디 입니다");
         }
 
-        MemoryUser memoryUser = MemoryUser.builder()
-                .identifier(signUpRequestDto.identifier())
-                .password(signUpRequestDto.password())
-                .nickname(signUpRequestDto.nickname())
-                .build();
+        MemoryUser memoryUser = new MemoryUser(
+                signUpRequestDto.identifier(),
+                signUpRequestDto.password(),
+                signUpRequestDto.nickname()
+        );
         userRepository.save(memoryUser);
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
@@ -22,11 +22,10 @@ public class MemoryUserService implements UserService {
             throw new DuplicateIdentifierException("중복된 아이디 입니다");
         }
 
-        String nickname = signUpRequestDto.nickname() == null ? "" : signUpRequestDto.nickname();
         MemoryUser memoryUser = MemoryUser.builder()
                 .identifier(signUpRequestDto.identifier())
                 .password(signUpRequestDto.password())
-                .nickname(nickname)
+                .nickname(signUpRequestDto.nickname())
                 .build();
         userRepository.save(memoryUser);
     }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
@@ -5,27 +5,29 @@ import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
 import io.github.cokelee777.springsecurityjwtauth.exception.DuplicateIdentifierException;
 import io.github.cokelee777.springsecurityjwtauth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
+@Primary
 @Service
 @RequiredArgsConstructor
 public class MemoryUserService implements UserService {
 
-    private final UserRepository<MemoryUser> memoryUserRepository;
+    private final UserRepository<MemoryUser> userRepository;
 
     @Override
     public void createUser(SignUpRequestDto signUpRequestDto) {
-        boolean isDuplicated = memoryUserRepository.existsByIdentifier(signUpRequestDto.identifier());
+        boolean isDuplicated = userRepository.existsByIdentifier(signUpRequestDto.identifier());
         if(isDuplicated) {
             throw new DuplicateIdentifierException("중복된 아이디 입니다");
         }
 
         String nickname = signUpRequestDto.nickname() == null ? "" : signUpRequestDto.nickname();
-        MemoryUser user = new MemoryUser(
-                signUpRequestDto.identifier(),
-                signUpRequestDto.password(),
-                nickname
-        );
-        memoryUserRepository.save(user);
+        MemoryUser memoryUser = MemoryUser.builder()
+                .identifier(signUpRequestDto.identifier())
+                .password(signUpRequestDto.password())
+                .nickname(nickname)
+                .build();
+        userRepository.save(memoryUser);
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserService.java
@@ -1,0 +1,31 @@
+package io.github.cokelee777.springsecurityjwtauth.service;
+
+import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
+import io.github.cokelee777.springsecurityjwtauth.exception.DuplicateIdentifierException;
+import io.github.cokelee777.springsecurityjwtauth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemoryUserService implements UserService {
+
+    private final UserRepository<MemoryUser> memoryUserRepository;
+
+    @Override
+    public void createUser(SignUpRequestDto signUpRequestDto) {
+        boolean isDuplicated = memoryUserRepository.existsByIdentifier(signUpRequestDto.identifier());
+        if(isDuplicated) {
+            throw new DuplicateIdentifierException("중복된 아이디 입니다");
+        }
+
+        String nickname = signUpRequestDto.nickname() == null ? "" : signUpRequestDto.nickname();
+        MemoryUser user = new MemoryUser(
+                signUpRequestDto.identifier(),
+                signUpRequestDto.password(),
+                nickname
+        );
+        memoryUserRepository.save(user);
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/UserService.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/service/UserService.java
@@ -1,0 +1,8 @@
+package io.github.cokelee777.springsecurityjwtauth.service;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
+
+public interface UserService {
+
+    void createUser(SignUpRequestDto signUpRequestDto);
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/utils/DefaultHttpMessage.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/utils/DefaultHttpMessage.java
@@ -8,5 +8,6 @@ public interface DefaultHttpMessage {
     String NOT_FOUND = "페이지 요청이 존재하지 않습니다.";
     String METHOD_NOT_ALLOWED = "허용되지 않은 HTTP 메서드 입니다.";
     String CONFLICT = "중복된 요청입니다.";
+    String UNSUPPORTED_MEDIA_TYPE = "허용되지 않은 컨텐츠 타입입니다.";
     String INTERNAL_SERVER_ERROR = "서버 내부 오류";
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/utils/DefaultHttpMessage.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/utils/DefaultHttpMessage.java
@@ -1,0 +1,12 @@
+package io.github.cokelee777.springsecurityjwtauth.utils;
+
+public interface DefaultHttpMessage {
+    String OK = "요청에 성공하였습니다.";
+    String UNAUTHORIZED = "인증이 필요한 요청입니다.";
+    String BAD_REQUEST = "잘못된 요청입니다.";
+    String FORBIDDEN = "승인이 필요한 페이지 요청입니다.";
+    String NOT_FOUND = "페이지 요청이 존재하지 않습니다.";
+    String METHOD_NOT_ALLOWED = "허용되지 않은 HTTP 메서드 입니다.";
+    String CONFLICT = "중복된 요청입니다.";
+    String INTERNAL_SERVER_ERROR = "서버 내부 오류";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,12 @@
+server:
+  error:
+    whitelabel:
+      enabled: false
 
+# 커스텀 NOT FOUND ERROR를 생성하기 위해 기본 page not found exception 제거
+spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false

--- a/src/test/java/io/github/cokelee777/springsecurityjwtauth/SpringSecurityJwtAuthApplicationTests.java
+++ b/src/test/java/io/github/cokelee777/springsecurityjwtauth/SpringSecurityJwtAuthApplicationTests.java
@@ -10,4 +10,5 @@ class SpringSecurityJwtAuthApplicationTests {
     void contextLoads() {
     }
 
+
 }

--- a/src/test/java/io/github/cokelee777/springsecurityjwtauth/controller/UserControllerTest.java
+++ b/src/test/java/io/github/cokelee777/springsecurityjwtauth/controller/UserControllerTest.java
@@ -1,0 +1,117 @@
+package io.github.cokelee777.springsecurityjwtauth.controller;
+
+import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
+import io.github.cokelee777.springsecurityjwtauth.service.UserService;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import jakarta.annotation.Nonnull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private Map<String, MemoryUser> memoryStore;
+
+    private static final String EXISTS_USER_IDENTIFIER = "existsUser123@naver.com";
+
+    @BeforeEach
+    void beforeEach() {
+
+        SignUpRequestDto signUpRequestDto = new SignUpRequestDto(
+                EXISTS_USER_IDENTIFIER, "existsUser123!", "existsUser");
+        userService.createUser(signUpRequestDto);
+    }
+
+    @AfterEach
+    void afterEach() {
+        memoryStore.clear();
+    }
+
+    private MvcResult postRequestMockServer(
+            @Nonnull String path,
+            @Nonnull HttpStatus status,
+            @Nonnull String message,
+            @Nonnull String requestBody) throws Exception {
+        return mockMvc.perform(post(path)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestBody))
+                .andExpect(status().is(status.value()))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$..['code']").value(status.name()))
+                .andExpect(jsonPath("$..['message']").value(message))
+                .andReturn();
+    }
+
+    @Test
+    void signUpSuccess() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "identifier": "user123@naver.com",
+                    "password": "user123!"
+                }""";
+
+        // when, then
+        postRequestMockServer("/sign-up", HttpStatus.OK, DefaultHttpMessage.OK, requestBody);
+    }
+
+    @Test
+    void signUpFailByValidationException() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "identifier": "user123",
+                    "password": "user123!"
+                }""";
+
+        // when, then
+        postRequestMockServer("/sign-up", HttpStatus.BAD_REQUEST, DefaultHttpMessage.BAD_REQUEST, requestBody);
+    }
+
+    @Test
+    void signUpFailBySyntaxException() throws Exception {
+        // given
+        String requestBody = """
+                {
+                    "identifier": "user123@naver.com",
+                    "password": }""";
+
+        // when, then
+        postRequestMockServer("/sign-up", HttpStatus.BAD_REQUEST, DefaultHttpMessage.BAD_REQUEST, requestBody);
+    }
+
+    @Test
+    void signUpFailByDuplicateIdentifierException() throws Exception {
+        // given
+        String requestBody = String.format("""
+                {
+                    "identifier": "%s",
+                    "password": "user123!"
+                }""", EXISTS_USER_IDENTIFIER);
+
+        // when, then
+        postRequestMockServer("/sign-up", HttpStatus.CONFLICT, DefaultHttpMessage.CONFLICT, requestBody);
+    }
+}

--- a/src/test/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepositoryTest.java
+++ b/src/test/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepositoryTest.java
@@ -1,0 +1,60 @@
+package io.github.cokelee777.springsecurityjwtauth.repository;
+
+import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+@SpringBootTest
+class MemoryUserRepositoryTest {
+
+    @Autowired
+    private UserRepository<MemoryUser> memoryUserRepository;
+
+    @Autowired
+    private Map<String, MemoryUser> memoryStore;
+
+    @AfterEach
+    void afterEach() {
+        memoryStore.clear();
+    }
+
+    @Test
+    void save() {
+        // given
+        MemoryUser memoryUser = MemoryUser.builder()
+                .identifier("user123@naver.com")
+                .password("user123!")
+                .nickname("testuser")
+                .build();
+
+        // when
+        memoryUserRepository.save(memoryUser);
+
+        // then
+        Assertions.assertThat(memoryStore.containsValue(memoryUser)).isTrue();
+    }
+
+    @Test
+    void existsByIdentifier() {
+        // given
+        MemoryUser memoryUser = MemoryUser.builder()
+                .identifier("existUser123@naver.com")
+                .password("existUser123!")
+                .nickname("existUser")
+                .build();
+        memoryUserRepository.save(memoryUser);
+
+        // when
+        boolean isExists = memoryUserRepository.existsByIdentifier("existUser123@naver.com");
+        boolean isNotExists = memoryUserRepository.existsByIdentifier("notExistUser123@naver.com");
+
+        //then
+        Assertions.assertThat(isExists).isTrue();
+        Assertions.assertThat(isNotExists).isFalse();
+    }
+}

--- a/src/test/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepositoryTest.java
+++ b/src/test/java/io/github/cokelee777/springsecurityjwtauth/repository/MemoryUserRepositoryTest.java
@@ -26,11 +26,11 @@ class MemoryUserRepositoryTest {
     @Test
     void save() {
         // given
-        MemoryUser memoryUser = MemoryUser.builder()
-                .identifier("user123@naver.com")
-                .password("user123!")
-                .nickname("testuser")
-                .build();
+        MemoryUser memoryUser = new MemoryUser(
+                "user123@naver.com",
+                "user123!",
+                "testuser"
+        );
 
         // when
         memoryUserRepository.save(memoryUser);
@@ -42,11 +42,11 @@ class MemoryUserRepositoryTest {
     @Test
     void existsByIdentifier() {
         // given
-        MemoryUser memoryUser = MemoryUser.builder()
-                .identifier("existUser123@naver.com")
-                .password("existUser123!")
-                .nickname("existUser")
-                .build();
+        MemoryUser memoryUser = new MemoryUser(
+                "existUser123@naver.com",
+                "existUser123!",
+                "existUser"
+        );
         memoryUserRepository.save(memoryUser);
 
         // when

--- a/src/test/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserServiceTest.java
+++ b/src/test/java/io/github/cokelee777/springsecurityjwtauth/service/MemoryUserServiceTest.java
@@ -1,0 +1,56 @@
+package io.github.cokelee777.springsecurityjwtauth.service;
+
+import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
+import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
+import io.github.cokelee777.springsecurityjwtauth.exception.DuplicateIdentifierException;
+import io.github.cokelee777.springsecurityjwtauth.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+
+@SpringBootTest
+class MemoryUserServiceTest {
+
+    @Autowired
+    private UserService memoryUserService;
+
+    @Autowired
+    private UserRepository<MemoryUser> memoryUserRepository;
+
+    @Autowired
+    private Map<String, MemoryUser> memoryStore;
+
+    @AfterEach
+    void afterEach() {
+        memoryStore.clear();
+    }
+
+    @Test
+    void createUserSuccess() {
+        // given
+        SignUpRequestDto signUpRequestDto =
+                new SignUpRequestDto("user123@naver.com", "user123!", "user123");
+
+        // when
+        memoryUserService.createUser(signUpRequestDto);
+
+        // then
+        Assertions.assertThat(memoryUserRepository.existsByIdentifier(signUpRequestDto.identifier())).isTrue();
+    }
+
+    @Test
+    void createUserDuplicateIdentifierException() {
+        // given
+        SignUpRequestDto signUpRequestDto =
+                new SignUpRequestDto("user123@naver.com", "user123!", "user123");
+        memoryUserService.createUser(signUpRequestDto);
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> memoryUserService.createUser(signUpRequestDto))
+                .isInstanceOf(DuplicateIdentifierException.class);
+    }
+}


### PR DESCRIPTION
## 제목

회원가입 API 구현

## 작업 내용

1.  DAO 계층 확장 가능하게 로직 구현

제네릭을 사용하여 어떤 사용자인지(메모리 사용자, DB 사용자) 구분

메모리 DB는 스프링 빈으로 등록하여 스프링 컨테이너에서 생명주기를 관리하게끔 구현

메모리 유저 DAO 계층을 최우선 빈으로 등록

2.  비즈니스 로직 구현

비즈니스 로직도 마찬가지로 확장이 가능하도록 설계

회원 중복 체크 로직으로 중복 예외 발생시 예외 핸들러가 처리 후 API 응답

메모리 유저 서비스 계층을 최우선 빈으로 등록

3. 모든 예외 처리(검증 및 클라이언트 오류)

500 Server error, 4XX Client error 예외 핸들러 구현

4.  테스트 코드 작성

회원가입 API 로직에 대한 단위, 통합, 인수 테스트 진행