### PR TITLE
[FEATURE] 인증 필터 구현

### DIFF
--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/SignInRequestDto.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/SignInRequestDto.java
@@ -1,0 +1,4 @@
+package io.github.cokelee777.springsecurityjwtauth.dto;
+
+public record SignInRequestDto(String identifier, String password) {
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/auth/JwtAuthenticationToken.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/auth/JwtAuthenticationToken.java
@@ -1,0 +1,63 @@
+package io.github.cokelee777.springsecurityjwtauth.security.auth;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.util.Assert;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+
+    private Object credentials;
+
+    public JwtAuthenticationToken(Object principal, Object credentials) {
+        super(null);
+        this.principal = principal;
+        this.credentials = credentials;
+        setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+                                  Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true); // must use super, as we override
+    }
+
+    // 인증 처리 전 호출
+    public static UsernamePasswordAuthenticationToken unauthenticated(Object principal, Object credentials) {
+        return new UsernamePasswordAuthenticationToken(principal, credentials);
+    }
+
+    // 인증 처리 후 호출(인증이 완료되었다고 setAuthenticated를 true로 변경 후 호출)
+    public static UsernamePasswordAuthenticationToken authenticated(
+            Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        return new UsernamePasswordAuthenticationToken(principal, credentials, authorities);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    @Override
+    public void setAuthenticated(boolean authenticated) {
+        Assert.isTrue(!isAuthenticated(), "신뢰할 수 없는 토큰값 입니다");
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        this.credentials = null;
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -1,11 +1,13 @@
 package io.github.cokelee777.springsecurityjwtauth.security.config;
 
+import io.github.cokelee777.springsecurityjwtauth.security.filter.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -28,6 +30,9 @@ public class JwtSecurityConfiguration {
         http.authorizeHttpRequests()
             .requestMatchers(PUBLIC_END_POINT).permitAll()
             .anyRequest().authenticated();
+
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter();
+        http.addFilterAfter(jwtAuthenticationFilter, LogoutFilter.class);
 
         return http.build();
     }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package io.github.cokelee777.springsecurityjwtauth.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cokelee777.springsecurityjwtauth.dto.SignInRequestDto;
+import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtAuthenticationToken;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final String SIGN_IN_END_POINT = "/sign-in";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JwtAuthenticationFilter() {
+        super(new AntPathRequestMatcher(SIGN_IN_END_POINT, HttpMethod.POST.name()));
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException, ServletException {
+        // 클라이언트 요청 검증
+        SignInRequestDto signInRequestDto;
+        try {
+            signInRequestDto = objectMapper.readValue(request.getReader(), SignInRequestDto.class);
+        } catch(IOException e) {
+            throw new AuthenticationServiceException("잘못된 JSON 요청 형식입니다");
+        }
+
+        // 사용자 입력값 검증
+        String identifier = validateAndObtainIdentifier(signInRequestDto);
+        String password = validateAndObtainPassword(signInRequestDto);
+
+        UsernamePasswordAuthenticationToken authRequest = JwtAuthenticationToken.unauthenticated(identifier, password);
+
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+
+    @Nonnull
+    protected String validateAndObtainIdentifier(SignInRequestDto signInRequestDto) {
+        if(!StringUtils.hasText(signInRequestDto.identifier())) {
+            throw new AuthenticationServiceException("아이디를 입력해주세요");
+        }
+        return signInRequestDto.identifier().trim();
+    }
+
+    @Nonnull
+    protected String validateAndObtainPassword(SignInRequestDto signInRequestDto) {
+        if(!StringUtils.hasText(signInRequestDto.password())) {
+            throw new AuthenticationServiceException("비밀번호를 입력해주세요");
+        }
+        return signInRequestDto.password();
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.cokelee777.springsecurityjwtauth.dto.SignInRequestDto;
 import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtAuthenticationToken;
 import jakarta.annotation.Nonnull;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpMethod;
@@ -30,7 +29,7 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
-            throws AuthenticationException, ServletException {
+            throws AuthenticationException {
         // 클라이언트 요청 검증
         SignInRequestDto signInRequestDto;
         try {


### PR DESCRIPTION
## 제목

인증 필터 로직 구현

## 작업 내용

1. AuthenticationFilter 로직 구현

AuthenticationFilter 로직을 구현하여 시큐리티 설정정보에 추가하였다. 이 필터는 원래 보통 인증 필터의 위치인 LogOutFilter 바로 뒤에 추가하였다.

필터에서는 클라이언트 입력값 검증 및 URL 매핑 검증과 실제 인증 처리를 하는 클래스에게 가짜 토큰을 넘기는 역할을 수행한다.

2. 로그인 DTO 구현

사용자 입력값을 객체에서 관리하기 위해 생성하였다.

3. 가짜 토큰 클래스 생성

가짜 토큰 클래스는 실제 인증 클래스에게 들어갈때, 가짜 토큰 클래스의 멤버 변수인 authenticated=false 를 부여해 아직 인증이 완료되지 않았다는 상태로 들어가고, 인증이 완료되면 authenticated=true로 반환되어 실제 인증이 되었는지 안되었는지 판단 유무로 사용한다.

또한 이 가짜 토큰 객체를 처리할 수 있는 실제 인증처리 객체가 존재하는지 여부도 판단할 수 있다.

