### PR TITLE
[FEATURE] 인증 성공, 실패 핸들러 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5','io.jsonwebtoken:jjwt-jackson:0.11.5'
 //    compileOnly 'org.projectlombok:lombok'
 //    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/MainConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/MainConfiguration.java
@@ -3,6 +3,10 @@ package io.github.cokelee777.springsecurityjwtauth;
 import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
 import io.github.cokelee777.springsecurityjwtauth.repository.MemoryUserRepository;
 import io.github.cokelee777.springsecurityjwtauth.repository.UserRepository;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.CustomAuthenticationFailureHandler;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.JwtAuthenticationFailureHandler;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.success.CustomAuthenticationSuccessHandler;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.success.JwtMemoryAuthenticationSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.service.JwtMemoryUserDetailsService;
 import io.github.cokelee777.springsecurityjwtauth.security.service.PrincipalUserDetailsService;
 import io.github.cokelee777.springsecurityjwtauth.security.token.creator.MemoryJwtTokenCreator;
@@ -61,4 +65,14 @@ public class MainConfiguration {
     @Bean
     @SuppressWarnings("unchecked")
     public <T extends TokenService> T tokenService() { return (T) new MemoryJwtTokenService(tokenProvider()); }
+
+    @Bean
+    public CustomAuthenticationFailureHandler customAuthenticationFailureHandler() {
+        return new JwtAuthenticationFailureHandler();
+    }
+
+    @Bean
+    public CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler() {
+        return new JwtMemoryAuthenticationSuccessHandler(tokenService());
+    }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -1,6 +1,8 @@
 package io.github.cokelee777.springsecurityjwtauth.security.config;
 
 import io.github.cokelee777.springsecurityjwtauth.security.filter.JwtAuthenticationFilter;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.CustomAuthenticationFailureHandler;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.success.CustomAuthenticationSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.provider.JwtAuthenticationProvider;
 import io.github.cokelee777.springsecurityjwtauth.security.service.PrincipalUserDetailsService;
 import org.springframework.context.annotation.Bean;
@@ -22,10 +24,14 @@ public class JwtSecurityConfiguration {
 
     private final PrincipalUserDetailsService jwtUserDetailsService;
     private final PasswordEncoder passwordEncoder;
+    private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+    private final CustomAuthenticationFailureHandler customAuthenticationFailureHandler;
 
-    public JwtSecurityConfiguration(PrincipalUserDetailsService jwtUserDetailsService, PasswordEncoder passwordEncoder) {
+    public JwtSecurityConfiguration(PrincipalUserDetailsService jwtUserDetailsService, PasswordEncoder passwordEncoder, CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler, CustomAuthenticationFailureHandler customAuthenticationFailureHandler) {
         this.jwtUserDetailsService = jwtUserDetailsService;
         this.passwordEncoder = passwordEncoder;
+        this.customAuthenticationSuccessHandler = customAuthenticationSuccessHandler;
+        this.customAuthenticationFailureHandler = customAuthenticationFailureHandler;
     }
 
     @Bean
@@ -57,9 +63,10 @@ public class JwtSecurityConfiguration {
         public void configure(HttpSecurity http) {
             AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
             JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager);
+            jwtAuthenticationFilter.setAuthenticationSuccessHandler(customAuthenticationSuccessHandler);
+            jwtAuthenticationFilter.setAuthenticationFailureHandler(customAuthenticationFailureHandler);
             http.addFilterAfter(jwtAuthenticationFilter, LogoutFilter.class)
                     .authenticationProvider(new JwtAuthenticationProvider(jwtUserDetailsService, passwordEncoder));
         }
     }
-
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/failure/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/failure/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,12 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.failure;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public interface CustomAuthenticationFailureHandler extends AuthenticationFailureHandler {
+    void setErrorResponse(HttpStatus status, HttpServletResponse response,
+                                 String message, String details) throws IOException;
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/failure/JwtAuthenticationFailureHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/failure/JwtAuthenticationFailureHandler.java
@@ -1,0 +1,46 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.failure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class JwtAuthenticationFailureHandler implements CustomAuthenticationFailureHandler {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        String message = exception.getMessage();
+
+        if (exception instanceof AuthenticationServiceException
+                || exception instanceof BadCredentialsException
+                || exception instanceof UsernameNotFoundException) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, DefaultHttpMessage.UNAUTHORIZED, message);
+        } else {
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, response,
+                    DefaultHttpMessage.INTERNAL_SERVER_ERROR, message);
+        }
+    }
+
+    @Override
+    public void setErrorResponse(HttpStatus status, HttpServletResponse response,
+                                 String message, String details) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+        objectMapper.writeValue(response.getWriter(),
+                new ExceptionResponseBody(status.getReasonPhrase(), message, details));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,10 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.success;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+public interface CustomAuthenticationSuccessHandler extends AuthenticationSuccessHandler {
+    void setDefaultResponse(HttpServletResponse response) throws IOException;
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtAuthenticationSuccessHandler.java
@@ -1,0 +1,14 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.success;
+
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.jwt.JwtAccessToken;
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.jwt.JwtRefreshToken;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.UnsupportedEncodingException;
+
+public interface JwtAuthenticationSuccessHandler extends CustomAuthenticationSuccessHandler{
+
+    void setHeaderWithJwtAccessToken(HttpServletResponse response, JwtAccessToken accessToken);
+
+    void setCookieWithJwtRefreshToken(HttpServletResponse response, JwtRefreshToken refreshToken) throws UnsupportedEncodingException;
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
@@ -1,0 +1,71 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.success;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtMemoryUserDetails;
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.jwt.JwtAccessToken;
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.jwt.JwtRefreshToken;
+import io.github.cokelee777.springsecurityjwtauth.security.token.service.MemoryJwtTokenService;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static io.github.cokelee777.springsecurityjwtauth.security.token.common.TokenProperties.COOKIE_EXPIRED_SECOND;
+
+public class JwtMemoryAuthenticationSuccessHandler implements JwtAuthenticationSuccessHandler {
+
+    private final MemoryJwtTokenService memoryJwtTokenService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public JwtMemoryAuthenticationSuccessHandler(MemoryJwtTokenService memoryJwtTokenService) {
+        this.memoryJwtTokenService = memoryJwtTokenService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        JwtMemoryUserDetails jwtMemoryUserDetails = (JwtMemoryUserDetails) authentication.getPrincipal();
+
+        JwtAccessToken accessToken = memoryJwtTokenService.issueAccessToken(jwtMemoryUserDetails);
+        JwtRefreshToken refreshToken = memoryJwtTokenService.issueRefreshToken(jwtMemoryUserDetails);
+
+        setDefaultResponse(response);
+        setHeaderWithJwtAccessToken(response, accessToken);
+        setCookieWithJwtRefreshToken(response, refreshToken);
+    }
+
+    @Override
+    public void setDefaultResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+        objectMapper.writeValue(response.getWriter(),
+                new SuccessResponseBody<>(HttpStatus.OK.getReasonPhrase(), DefaultHttpMessage.OK, null));
+    }
+
+    @Override
+    public void setHeaderWithJwtAccessToken(HttpServletResponse response, JwtAccessToken accessToken) {
+        response.setHeader("Authorization", accessToken.getValue());
+    }
+
+    @Override
+    public void setCookieWithJwtRefreshToken(HttpServletResponse response,
+                                             JwtRefreshToken refreshToken) throws UnsupportedEncodingException {
+        String encodedValue = URLEncoder.encode(refreshToken.getValue(), "UTF-8") ;
+        Cookie cookie = new Cookie("Authorization", encodedValue);
+        cookie.setMaxAge(COOKIE_EXPIRED_SECOND);
+        cookie.setHttpOnly(true);
+        // setSecure을 true로 할 시 HTTPS 에서만 접근 가능하기 때문
+//        cookie.setSecure(true);
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
@@ -38,9 +38,9 @@ public class JwtMemoryAuthenticationSuccessHandler implements JwtAuthenticationS
         JwtAccessToken accessToken = memoryJwtTokenService.issueAccessToken(jwtMemoryUserDetails);
         JwtRefreshToken refreshToken = memoryJwtTokenService.issueRefreshToken(jwtMemoryUserDetails);
 
-        setDefaultResponse(response);
         setHeaderWithJwtAccessToken(response, accessToken);
         setCookieWithJwtRefreshToken(response, refreshToken);
+        setDefaultResponse(response);
     }
 
     @Override

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/provider/JwtAuthenticationProvider.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
         // 인증 완료시 authenticated 메서드 호출
         return JwtAuthenticationToken
-                .authenticated(userDetails.getUsername(), userDetails.getPassword(), userDetails.getAuthorities());
+                .authenticated(userDetails, null, userDetails.getAuthorities());
     }
 
     // 인증 객체가 Jwt 인증 토큰과 정확히 일치할 경우만 true

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/common/TokenProperties.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/common/TokenProperties.java
@@ -4,21 +4,18 @@ import io.jsonwebtoken.SignatureAlgorithm;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 public interface TokenProperties {
-    String TOKEN_PREFIX = "Bearer ";
+    String ACCESS_TOKEN_PREFIX = "Bearer ";
     SecretKey SECRET_KEY = new SecretKeySpec(
-            System.getProperty("jwt.secretKey").trim().getBytes(StandardCharsets.UTF_8)
+            "YouNeedASecretKeyThatIsAtLeast64BytesLongPleaseCheckYourSecretKeyLength".trim().getBytes(StandardCharsets.UTF_8)
             , SignatureAlgorithm.HS256.getJcaName());
-
     SecretKey REFRESH_KEY = new SecretKeySpec(
-            System.getProperty("jwt.refreshKey").trim().getBytes(StandardCharsets.UTF_8)
+            "YouNeedARefreshKeyThatIsAtLeast64BytesLongPleaseCheckYourRefreshKeyLength".trim().getBytes(StandardCharsets.UTF_8)
             , SignatureAlgorithm.HS256.getJcaName());
-
-    Long ACCESS_TOKEN_EXPIRED_TIME = Duration.ofMinutes(30).toMillis();
-    Long REFRESH_TOKEN_EXPIRED_TIME = Duration.ofDays(14).toMillis();
-
+    Long ACCESS_TOKEN_EXPIRED_TIME = Duration.ofMinutes(5).toMillis();
+    Long REFRESH_TOKEN_EXPIRED_TIME = Duration.ofDays(30).toMillis();
+    int COOKIE_EXPIRED_SECOND = (int) Duration.ofDays(30).toSeconds();
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/creator/MemoryJwtTokenCreator.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/creator/MemoryJwtTokenCreator.java
@@ -10,11 +10,12 @@ import java.util.UUID;
 import static io.github.cokelee777.springsecurityjwtauth.security.token.common.TokenProperties.*;
 
 public class MemoryJwtTokenCreator implements JwtTokenCreator<JwtMemoryUserDetails> {
+
     @Override
     public String createAccessToken(JwtMemoryUserDetails jwtMemoryUserDetails) {
         Date now = new Date();
         Claims claims = setClaims(jwtMemoryUserDetails);
-        return TOKEN_PREFIX + Jwts.builder()
+        return ACCESS_TOKEN_PREFIX + Jwts.builder()
                 .setSubject(jwtMemoryUserDetails.getId())
                 .setClaims(claims)
                 .setIssuedAt(now)
@@ -27,7 +28,7 @@ public class MemoryJwtTokenCreator implements JwtTokenCreator<JwtMemoryUserDetai
     public String createRefreshToken(JwtMemoryUserDetails jwtMemoryUserDetails) {
         Date now = new Date();
         Claims claims = setClaims(jwtMemoryUserDetails);
-        return TOKEN_PREFIX + Jwts.builder()
+        return Jwts.builder()
                 .setSubject(jwtMemoryUserDetails.getId())
                 .setClaims(claims)
                 .setIssuedAt(now)

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/AccessToken.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/AccessToken.java
@@ -17,7 +17,7 @@ public abstract class AccessToken implements Token {
     private Date getDefaultExpiredAt() {
         return new Date(this.createdAt.getTime() + ACCESS_TOKEN_EXPIRED_TIME);
     }
-    
+
     public String getValue() {
         return value;
     }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/AccessToken.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/AccessToken.java
@@ -17,4 +17,8 @@ public abstract class AccessToken implements Token {
     private Date getDefaultExpiredAt() {
         return new Date(this.createdAt.getTime() + ACCESS_TOKEN_EXPIRED_TIME);
     }
+    
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/RefreshToken.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/RefreshToken.java
@@ -17,4 +17,8 @@ public abstract class RefreshToken implements Token {
     private Date getDefaultExpiredAt() {
         return new Date(this.createdAt.getTime() + REFRESH_TOKEN_EXPIRED_TIME);
     }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/Token.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/Token.java
@@ -1,8 +1,9 @@
 package io.github.cokelee777.springsecurityjwtauth.security.token.domain;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public interface Token {
+public interface Token extends Serializable {
 
     Date createdAt = new Date();
 

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/Token.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/domain/Token.java
@@ -1,9 +1,8 @@
 package io.github.cokelee777.springsecurityjwtauth.security.token.domain;
 
-import java.io.Serializable;
 import java.util.Date;
 
-public interface Token extends Serializable {
+public interface Token {
 
     Date createdAt = new Date();
 

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/service/MemoryJwtTokenService.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/service/MemoryJwtTokenService.java
@@ -3,6 +3,8 @@ package io.github.cokelee777.springsecurityjwtauth.security.token.service;
 import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtMemoryUserDetails;
 import io.github.cokelee777.springsecurityjwtauth.security.token.domain.AccessToken;
 import io.github.cokelee777.springsecurityjwtauth.security.token.domain.RefreshToken;
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.jwt.JwtAccessToken;
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.jwt.JwtRefreshToken;
 import io.github.cokelee777.springsecurityjwtauth.security.token.provider.MemoryJwtTokenProvider;
 
 public class MemoryJwtTokenService implements JwtTokenService<JwtMemoryUserDetails> {
@@ -16,14 +18,14 @@ public class MemoryJwtTokenService implements JwtTokenService<JwtMemoryUserDetai
     @SuppressWarnings("unchecked")
     @Override
     public <S extends AccessToken> S issueAccessToken(JwtMemoryUserDetails jwtUserDetails) {
-        AccessToken accessToken = memoryJwtTokenProvider.getAccessToken(jwtUserDetails);
+        JwtAccessToken accessToken = memoryJwtTokenProvider.getAccessToken(jwtUserDetails);
         return (S) accessToken;
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <U extends RefreshToken> U issueRefreshToken(JwtMemoryUserDetails jwtUserDetails) {
-        RefreshToken refreshToken = memoryJwtTokenProvider.getRefreshToken(jwtUserDetails);
+        JwtRefreshToken refreshToken = memoryJwtTokenProvider.getRefreshToken(jwtUserDetails);
         return (U) refreshToken;
     }
 }


### PR DESCRIPTION
## 제목
Jwt기반으로 실제 토큰을 생성하고 제공하는 로직 구현

## 작업 내용
1. jjwt-jackson 라이브러리 추가

jjwt를 사용하기 위해 필요한 라이브러리를 build 파일에 추가

2. 인증 실패 핸들러 구현

모든 인증 실패 핸들러에서 사용하는 로직을 상위 인터페이스의 메서드로 정의하고 jwt 관련 인증 실패 핸들러를 구현

3. 인증 성공 핸들러 구현

모든 인증 성공 핸들러에서 사용하는 로직(default 응답)을 상위 인터페이스의 메서드로 정의하고 jwt 관련 인증 실패 핸들러를 구현

4. handler 관련 configuration 설정

구현한 handler를 spring bean으로 등록하였으며, security configuration에 추가하였음

5. 테스트 중 발생한 오류 해결

테스트 중 발생한 오류 들을 코드 수정을 통해 해결하였으며, 후에 refreshToken 관련 수정이 필요함(쿠키에서 `space`가 `+`로 바뀌는 부분)
