### PR TITLE
[FEATURE] 인가 처리 

### DIFF
--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/MainConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/MainConfiguration.java
@@ -3,17 +3,18 @@ package io.github.cokelee777.springsecurityjwtauth;
 import io.github.cokelee777.springsecurityjwtauth.domain.MemoryUser;
 import io.github.cokelee777.springsecurityjwtauth.repository.MemoryUserRepository;
 import io.github.cokelee777.springsecurityjwtauth.repository.UserRepository;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.CustomAccessDeniedHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.CustomAuthenticationFailureHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.JwtAuthenticationFailureHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.success.CustomAuthenticationSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.success.JwtMemoryAuthenticationSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.service.JwtMemoryUserDetailsService;
 import io.github.cokelee777.springsecurityjwtauth.security.service.PrincipalUserDetailsService;
-import io.github.cokelee777.springsecurityjwtauth.security.token.extractor.MemoryJwtTokenExtractor;
 import io.github.cokelee777.springsecurityjwtauth.security.token.creator.MemoryJwtTokenCreator;
 import io.github.cokelee777.springsecurityjwtauth.security.token.creator.TokenCreator;
 import io.github.cokelee777.springsecurityjwtauth.security.token.decoder.MemoryJwtTokenDecoder;
 import io.github.cokelee777.springsecurityjwtauth.security.token.decoder.TokenDecoder;
+import io.github.cokelee777.springsecurityjwtauth.security.token.extractor.MemoryJwtTokenExtractor;
 import io.github.cokelee777.springsecurityjwtauth.security.token.extractor.TokenExtractor;
 import io.github.cokelee777.springsecurityjwtauth.security.token.provider.MemoryJwtTokenProvider;
 import io.github.cokelee777.springsecurityjwtauth.security.token.provider.TokenProvider;
@@ -93,11 +94,18 @@ public class MainConfiguration {
     }
 
     @Bean
+    public CustomAccessDeniedHandler customAccessDeniedHandler() {
+        return new CustomAccessDeniedHandler();
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
     public <T extends TokenDecoder> T tokenDecoder() {
         return (T) new MemoryJwtTokenDecoder();
     }
 
     @Bean
+    @SuppressWarnings("unchecked")
     public <T extends TokenExtractor> T tokenExtractor() {
         return (T) new MemoryJwtTokenExtractor(userService(), tokenDecoder());
     }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/config/WebConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/config/WebConfiguration.java
@@ -1,0 +1,17 @@
+package io.github.cokelee777.springsecurityjwtauth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowCredentials(false)
+                .allowedHeaders("*")
+                .allowedOrigins("*");
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/config/WebConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/config/WebConfiguration.java
@@ -2,9 +2,11 @@ package io.github.cokelee777.springsecurityjwtauth.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableWebMvc
 public class WebConfiguration implements WebMvcConfigurer {
 
     @Override

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/AdminController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/AdminController.java
@@ -1,0 +1,20 @@
+package io.github.cokelee777.springsecurityjwtauth.controller;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<SuccessResponseBody<String>> getProfile() {
+        return ResponseEntity.ok()
+                .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, "admin dashboard"));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/HomeController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/HomeController.java
@@ -1,0 +1,18 @@
+package io.github.cokelee777.springsecurityjwtauth.controller;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @GetMapping("/")
+    public ResponseEntity<SuccessResponseBody<Void>> home() {
+        return ResponseEntity.ok()
+                .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, null));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/ManagerController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/ManagerController.java
@@ -1,0 +1,20 @@
+package io.github.cokelee777.springsecurityjwtauth.controller;
+
+import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/manager")
+public class ManagerController {
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<SuccessResponseBody<String>> getProfile() {
+        return ResponseEntity.ok()
+                .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, "manager dashboard"));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
@@ -7,11 +7,10 @@ import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/users")
 public class UserController {
 
     private final UserService userService;
@@ -23,6 +22,12 @@ public class UserController {
     @PostMapping("/sign-up")
     public ResponseEntity<SuccessResponseBody<Void>> signUp(@Valid @RequestBody SignUpRequestDto signUpRequestDto) {
         userService.createUser(signUpRequestDto);
+        return ResponseEntity.ok()
+                .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, null));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<SuccessResponseBody<Void>> getProfile() {
         return ResponseEntity.ok()
                 .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, null));
     }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/controller/UserController.java
@@ -1,12 +1,16 @@
 package io.github.cokelee777.springsecurityjwtauth.controller;
 
+import io.github.cokelee777.springsecurityjwtauth.dto.GetProfileResponseDto;
 import io.github.cokelee777.springsecurityjwtauth.dto.SignUpRequestDto;
 import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.enums.UserRole;
+import io.github.cokelee777.springsecurityjwtauth.security.auth.PrincipalUserDetails;
 import io.github.cokelee777.springsecurityjwtauth.service.UserService;
 import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,8 +31,13 @@ public class UserController {
     }
 
     @GetMapping("/profile")
-    public ResponseEntity<SuccessResponseBody<Void>> getProfile() {
+    public ResponseEntity<SuccessResponseBody<GetProfileResponseDto>> getProfile(
+            @AuthenticationPrincipal PrincipalUserDetails principalUserDetails) {
+        GetProfileResponseDto getProfileResponseDto =
+                new GetProfileResponseDto(principalUserDetails.getUsername(), UserRole.ROLE_USER.name());
         return ResponseEntity.ok()
-                .body(new SuccessResponseBody<>(HttpStatus.OK.name(), DefaultHttpMessage.OK, null));
+                .body(new SuccessResponseBody<>(
+                        HttpStatus.OK.name(),
+                        DefaultHttpMessage.OK, getProfileResponseDto));
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/domain/MemoryUser.java
@@ -11,7 +11,7 @@ public class MemoryUser implements User {
     private final String identifier;
     private final String password;
     private final String nickname;
-    private UserRole role = UserRole.USER;
+    private UserRole role = UserRole.ROLE_USER;
 
     public MemoryUser(String identifier, String password, String nickname) {
         this.identifier = identifier;

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/GetProfileResponseDto.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/dto/GetProfileResponseDto.java
@@ -1,0 +1,4 @@
+package io.github.cokelee777.springsecurityjwtauth.dto;
+
+public record GetProfileResponseDto(String identifier, String roleName) {
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/enums/UserRole.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/enums/UserRole.java
@@ -1,5 +1,5 @@
 package io.github.cokelee777.springsecurityjwtauth.enums;
 
 public enum UserRole {
-    USER, MANAGER, ADMIN
+    ROLE_USER, ROLE_MANAGER, ROLE_ADMIN
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -8,6 +8,7 @@ import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.Custo
 import io.github.cokelee777.springsecurityjwtauth.security.handler.success.CustomAuthenticationSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.provider.JwtAuthenticationProvider;
 import io.github.cokelee777.springsecurityjwtauth.security.service.PrincipalUserDetailsService;
+import io.github.cokelee777.springsecurityjwtauth.security.token.service.MemoryJwtTokenService;
 import io.github.cokelee777.springsecurityjwtauth.security.token.service.TokenService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -91,7 +92,7 @@ public class JwtSecurityConfiguration {
                     .authenticationProvider(new JwtAuthenticationProvider(principalUserDetailsService, passwordEncoder));
 
             JwtMemoryAuthorizationFilter jwtMemoryAuthorizationFilter =
-                    new JwtMemoryAuthorizationFilter(authenticationManager, tokenService);
+                    new JwtMemoryAuthorizationFilter(authenticationManager, (MemoryJwtTokenService) tokenService);
             JwtAuthorizationExceptionFilter jwtAuthorizationExceptionFilter = new JwtAuthorizationExceptionFilter();
             http.addFilterBefore(jwtMemoryAuthorizationFilter, JwtAuthenticationFilter.class);
             http.addFilterBefore(jwtAuthorizationExceptionFilter, JwtMemoryAuthorizationFilter.class);

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -60,7 +60,7 @@ public class JwtSecurityConfiguration {
 
         // 인가 API
         http.authorizeHttpRequests()
-            .requestMatchers(PUBLIC_END_POINT).permitAll()
+            .requestMatchers(PUBLIC_END_POINT).anonymous()
             .requestMatchers("/users/**")
                 .hasAnyRole("USER", "MANAGER", "ADMIN")
             .requestMatchers("/manager/**")

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
     private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER =
-            new AntPathRequestMatcher("/sign-in", HttpMethod.POST.name());
+            new AntPathRequestMatcher("/users/sign-in", HttpMethod.POST.name());
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthorizationExceptionFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthorizationExceptionFilter.java
@@ -1,0 +1,51 @@
+package io.github.cokelee777.springsecurityjwtauth.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.security.sasl.AuthenticationException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class JwtAuthorizationExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch(ExpiredJwtException e) {
+            setErrorResponse(
+                    HttpStatus.MOVED_PERMANENTLY,
+                    response,
+                    String.format(DefaultHttpMessage.MOVED_PERMANENTLY, "/users/sign-in"),
+                    e.getMessage());
+        } catch(JwtException | AuthenticationException e) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, DefaultHttpMessage.UNAUTHORIZED, e.getMessage());
+        } catch(IllegalArgumentException e) {
+            setErrorResponse(HttpStatus.BAD_REQUEST, response, DefaultHttpMessage.BAD_REQUEST, e.getMessage());
+        } catch(Exception e) {
+            setErrorResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR, response, DefaultHttpMessage.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse response, String message, String details) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+        objectMapper.writeValue(response.getWriter(),
+                new ExceptionResponseBody(status.getReasonPhrase(), message, details));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,4 @@
+package io.github.cokelee777.springsecurityjwtauth.security.filter;
+
+public interface JwtAuthorizationFilter {
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtAuthorizationFilter.java
@@ -1,4 +1,15 @@
 package io.github.cokelee777.springsecurityjwtauth.security.filter;
 
-public interface JwtAuthorizationFilter {
+import io.github.cokelee777.springsecurityjwtauth.security.token.service.TokenService;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+public abstract class JwtAuthorizationFilter<T extends TokenService> extends BasicAuthenticationFilter {
+
+    protected final T tokenService;
+
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, T tokenService) {
+        super(authenticationManager);
+        this.tokenService = tokenService;
+    }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtMemoryAuthorizationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtMemoryAuthorizationFilter.java
@@ -57,15 +57,20 @@ public class JwtMemoryAuthorizationFilter extends JwtAuthorizationFilter<MemoryJ
         } catch(ExpiredJwtException e1) {
             // 토큰이 만료되었다면 쿠키 검증
             Cookie[] cookies = request.getCookies();
-            // 쿠키가 존재하지 않는다면
+
+            // 쿠키가 비어있다면
             if(cookies == null) {
                 throw new IllegalArgumentException("쿠키가 존재하지 않습니다");
             }
+
+            boolean hasAuthorizationCookie = false;
             for (Cookie cookie : cookies) {
                 // 인증 쿠키인지 검증
                 if(!cookie.getName().equals(AUTHORIZATION_COOKIE_NAME)) {
                     continue;
                 }
+
+                hasAuthorizationCookie = true;
                 // 쿠키가 HttpOnly 속성을 가지고 있는지 검증
                 if(!cookie.isHttpOnly()) {
                     throw new AuthenticationException("변조된 쿠키입니다");
@@ -101,7 +106,10 @@ public class JwtMemoryAuthorizationFilter extends JwtAuthorizationFilter<MemoryJ
                     // 그냥 예외를 던진다
                     throw new ExpiredJwtException(e2.getHeader(), e2.getClaims(), e2.getMessage());
                 }
+            }
 
+            if(!hasAuthorizationCookie) {
+                throw new IllegalArgumentException("인증 쿠키가 존재하지 않습니다");
             }
         }
 

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtMemoryAuthorizationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtMemoryAuthorizationFilter.java
@@ -4,7 +4,6 @@ import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtAuthenticatio
 import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtMemoryUserDetails;
 import io.github.cokelee777.springsecurityjwtauth.security.token.domain.AccessToken;
 import io.github.cokelee777.springsecurityjwtauth.security.token.service.MemoryJwtTokenService;
-import io.github.cokelee777.springsecurityjwtauth.security.token.service.TokenService;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -15,24 +14,21 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 import javax.security.sasl.AuthenticationException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 
-public class JwtMemoryAuthorizationFilter extends BasicAuthenticationFilter implements JwtAuthorizationFilter {
+public class JwtMemoryAuthorizationFilter extends JwtAuthorizationFilter<MemoryJwtTokenService> {
 
     private static final String[] PUBLIC_END_POINT = {"/", "/users/sign-in", "/users/sign-up"};
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String AUTHORIZATION_COOKIE_NAME = "Authorization";
 
-    private final MemoryJwtTokenService tokenService;
-
-    public JwtMemoryAuthorizationFilter(AuthenticationManager authenticationManager, TokenService tokenService) {
-        super(authenticationManager);
-        this.tokenService = (MemoryJwtTokenService) tokenService;
+    public JwtMemoryAuthorizationFilter(
+            AuthenticationManager authenticationManager, MemoryJwtTokenService tokenService) {
+        super(authenticationManager, tokenService);
     }
 
     @Override

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtMemoryAuthorizationFilter.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/filter/JwtMemoryAuthorizationFilter.java
@@ -1,0 +1,117 @@
+package io.github.cokelee777.springsecurityjwtauth.security.filter;
+
+import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtAuthenticationToken;
+import io.github.cokelee777.springsecurityjwtauth.security.auth.JwtMemoryUserDetails;
+import io.github.cokelee777.springsecurityjwtauth.security.token.domain.AccessToken;
+import io.github.cokelee777.springsecurityjwtauth.security.token.service.MemoryJwtTokenService;
+import io.github.cokelee777.springsecurityjwtauth.security.token.service.TokenService;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.security.sasl.AuthenticationException;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class JwtMemoryAuthorizationFilter extends BasicAuthenticationFilter implements JwtAuthorizationFilter {
+
+    private static final String[] PUBLIC_END_POINT = {"/", "/users/sign-in", "/users/sign-up"};
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String AUTHORIZATION_COOKIE_NAME = "Authorization";
+
+    private final MemoryJwtTokenService tokenService;
+
+    public JwtMemoryAuthorizationFilter(AuthenticationManager authenticationManager, TokenService tokenService) {
+        super(authenticationManager);
+        this.tokenService = (MemoryJwtTokenService) tokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        // white label list 확인
+        if(Arrays.stream(PUBLIC_END_POINT).anyMatch(path -> path.equals(request.getRequestURI()))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Header 검증
+        String accessToken = request.getHeader(AUTHORIZATION_HEADER);
+        if(accessToken == null) {
+            throw new IllegalArgumentException("인증 헤더가 필요한 요청입니다");
+        }
+
+        JwtMemoryUserDetails jwtMemoryUserDetails;
+        try {
+            // 헤더 값으로 access token 검증
+            jwtMemoryUserDetails = tokenService.decodeAccessToken(accessToken);
+
+            // access token이 검증되었다면 인증 객체를 생성 후 시큐리티 컨텍스트에 인증 객체 저장
+            setAuthentication(jwtMemoryUserDetails);
+
+        } catch(ExpiredJwtException e1) {
+            // 토큰이 만료되었다면 쿠키 검증
+            Cookie[] cookies = request.getCookies();
+            // 쿠키가 존재하지 않는다면
+            if(cookies == null) {
+                throw new IllegalArgumentException("쿠키가 존재하지 않습니다");
+            }
+            for (Cookie cookie : cookies) {
+                // 인증 쿠키인지 검증
+                if(!cookie.getName().equals(AUTHORIZATION_COOKIE_NAME)) {
+                    continue;
+                }
+                // TODO: 쿠키가 HttpOnly 속성을 가지고 있는지 검증
+//                if(!cookie.isHttpOnly()) {
+//                    throw new AuthenticationException("변조된 쿠키입니다");
+//                }
+                // 쿠키가 만료되지 않았는지 검증
+                int expirationTime = cookie.getMaxAge();
+                int currentTime = (int) (System.currentTimeMillis() / 1000);
+                // 쿠키가 만료되었다면
+                if(expirationTime != -1 && expirationTime < currentTime) {
+                    throw new AuthenticationException("쿠키가 만료되었습니다");
+                }
+                // 쿠키 값으로 Refresh token 검증
+                String refreshToken = cookie.getValue();
+                try {
+                    jwtMemoryUserDetails = tokenService.decodeRefreshToken(refreshToken);
+
+                    // 검증이 완료되었다면 access token 재발급 후 헤더에 담는다
+                    AccessToken reIssuedAccessToken = tokenService.issueAccessToken(jwtMemoryUserDetails);
+                    response.setHeader(AUTHORIZATION_HEADER, reIssuedAccessToken.getValue());
+
+                    // refresh token이 검증되었다면 인증 객체를 생성
+                    setAuthentication(jwtMemoryUserDetails);
+
+                } catch(ExpiredJwtException e2) {
+                    // 리프레쉬 토큰도 만료가 되었다면 시큐리티 컨텍스트를 비우고
+                    SecurityContextHolder.clearContext();
+
+                    // 그냥 예외를 던진다
+                    throw new ExpiredJwtException(e2.getHeader(), e2.getClaims(), e2.getMessage());
+                }
+
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private static void setAuthentication(JwtMemoryUserDetails jwtMemoryUserDetails) {
+        Authentication authentication = JwtAuthenticationToken
+                .authenticated(jwtMemoryUserDetails, null, jwtMemoryUserDetails.getAuthorities());
+
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/failure/CustomAccessDeniedHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/failure/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.failure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cokelee777.springsecurityjwtauth.dto.common.ExceptionResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        setErrorResponse(HttpStatus.FORBIDDEN, response, DefaultHttpMessage.FORBIDDEN, accessDeniedException.getMessage());
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse response,
+                                 String message, String details) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+        objectMapper.writeValue(response.getWriter(),
+                new ExceptionResponseBody(status.getReasonPhrase(), message, details));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
@@ -15,7 +15,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -24,7 +23,7 @@ import static io.github.cokelee777.springsecurityjwtauth.security.token.common.T
 public class JwtMemoryAuthenticationSuccessHandler implements JwtAuthenticationSuccessHandler {
 
     private final MemoryJwtTokenService memoryJwtTokenService;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public JwtMemoryAuthenticationSuccessHandler(MemoryJwtTokenService memoryJwtTokenService) {
         this.memoryJwtTokenService = memoryJwtTokenService;
@@ -59,8 +58,8 @@ public class JwtMemoryAuthenticationSuccessHandler implements JwtAuthenticationS
 
     @Override
     public void setCookieWithJwtRefreshToken(HttpServletResponse response,
-                                             JwtRefreshToken refreshToken) throws UnsupportedEncodingException {
-        String encodedValue = URLEncoder.encode(refreshToken.getValue(), "UTF-8") ;
+                                             JwtRefreshToken refreshToken) {
+        String encodedValue = URLEncoder.encode(refreshToken.getValue(), StandardCharsets.UTF_8) ;
         Cookie cookie = new Cookie("Authorization", encodedValue);
         cookie.setMaxAge(COOKIE_EXPIRED_SECOND);
         cookie.setHttpOnly(true);

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/creator/MemoryJwtTokenCreator.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/creator/MemoryJwtTokenCreator.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 
 import java.util.Date;
-import java.util.UUID;
 
 import static io.github.cokelee777.springsecurityjwtauth.security.token.common.TokenProperties.*;
 
@@ -16,7 +15,6 @@ public class MemoryJwtTokenCreator implements JwtTokenCreator<JwtMemoryUserDetai
         Date now = new Date();
         Claims claims = setClaims(jwtMemoryUserDetails);
         return ACCESS_TOKEN_PREFIX + Jwts.builder()
-                .setSubject(jwtMemoryUserDetails.getId())
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRED_TIME))
@@ -29,7 +27,6 @@ public class MemoryJwtTokenCreator implements JwtTokenCreator<JwtMemoryUserDetai
         Date now = new Date();
         Claims claims = setClaims(jwtMemoryUserDetails);
         return Jwts.builder()
-                .setSubject(jwtMemoryUserDetails.getId())
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRED_TIME))
@@ -42,6 +39,7 @@ public class MemoryJwtTokenCreator implements JwtTokenCreator<JwtMemoryUserDetai
         claims.put("identifier", jwtMemoryUserDetails.getUsername());
         claims.put("nickname", jwtMemoryUserDetails.getNickname());
         claims.put("role", jwtMemoryUserDetails.getRole().toString());
+        claims.setSubject(jwtMemoryUserDetails.getId());
         return claims;
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/extractor/MemoryJwtTokenExtractor.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/token/extractor/MemoryJwtTokenExtractor.java
@@ -20,15 +20,13 @@ public class MemoryJwtTokenExtractor implements JwtTokenExtractor<JwtMemoryUserD
     @Override
     public JwtMemoryUserDetails extractAccessToken(String accessToken) {
         Claims claims = memoryJwtTokenDecoder.decodeAccessToken(accessToken);
-        JwtMemoryUserDetails jwtMemoryUserDetails = toJwtMemoryUserDetails(claims);
-        return jwtMemoryUserDetails;
+        return toJwtMemoryUserDetails(claims);
     }
 
     @Override
     public JwtMemoryUserDetails extractRefreshToken(String refreshToken) {
         Claims claims = memoryJwtTokenDecoder.decodeRefreshToken(refreshToken);
-        JwtMemoryUserDetails jwtMemoryUserDetails = toJwtMemoryUserDetails(claims);
-        return jwtMemoryUserDetails;
+        return toJwtMemoryUserDetails(claims);
     }
 
     private JwtMemoryUserDetails toJwtMemoryUserDetails(Claims claims) {
@@ -36,13 +34,11 @@ public class MemoryJwtTokenExtractor implements JwtTokenExtractor<JwtMemoryUserD
 
         verify(claims, memoryUser);
 
-        JwtMemoryUserDetails jwtMemoryUserDetails = new JwtMemoryUserDetails(memoryUser);
-        return jwtMemoryUserDetails;
+        return new JwtMemoryUserDetails(memoryUser);
     }
 
     private void verify(Claims claims, MemoryUser user) {
         if (!user.getId().equals(claims.getSubject())
-                || !user.getNickname().equals(claims.get("nickname", String.class))
                 || !user.getRole().toString().equals(claims.get("role", String.class))) {
             throw new MalformedJwtException("변조된 토큰입니다.");
         }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/utils/DefaultHttpMessage.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/utils/DefaultHttpMessage.java
@@ -2,6 +2,7 @@ package io.github.cokelee777.springsecurityjwtauth.utils;
 
 public interface DefaultHttpMessage {
     String OK = "요청에 성공하였습니다.";
+    String MOVED_PERMANENTLY = "영구적인 리다이렉션이 필요합니다. redirect=%s;";
     String UNAUTHORIZED = "인증이 필요한 요청입니다.";
     String BAD_REQUEST = "잘못된 요청입니다.";
     String FORBIDDEN = "승인이 필요한 페이지 요청입니다.";


### PR DESCRIPTION
## 제목

사용자 로그인 유지 또는 역할에 따른 페이지 제어를 위한 인가처리 로직 구현

## 작업 내용

1. 인가 처리를 위한 인가필터 구현

필터 동작방식

- 우선적으로 퍼블릭 엔드포인트를 확인해서 퍼블릭 엔드포인트를 통과하지 못하도록 구현
- 인증 헤더를 검증해서 엑세스 토큰이 있는지 확인
- 엑세스 토큰이 만료되지 않았다면 올바른 토큰인지 검증하고 올바른 토큰이면 시큐리티 컨텍스트에 저장하고 필터 통과
- 엑세스 토큰이 만료되었다면 쿠키에 리프레쉬 토큰이 있는지 확인
- 쿠키의 속성들을 검증
- 쿠키 속성이 모두 유효하다면 리프레쉬 토큰을 검증하고 만료되지 않았다면 올바른 토큰인지 검증하고 올바른 토큰이면 시큐리티 컨텍스트에 저장하고 필터 통과
- 리프레쉬 토큰도 만료되었다면 시큐리티 컨텍스트를 비우고 로그인 화면으로 리다이렉트

2. 간단한 유저 프로필 조회 구현

3. 시큐리티 관련 버그 수정

- 시큐리티 기본 인가 매니저에서 검증하는 사용자 Role이 앞에 prefix로 'ROLE_' 이 붙기 때문에 기본 사용자 역할도 prefix로 'ROLE_'을 붙여서 해결
- 토큰 생성 시 Subject를 세팅하고 Claims를 나중에 세팅해서 Claims가 Subject를 덮어씌우는 문제 발생(실제 Subject는 Null이 들어감) -> Claims 안에 Subject를 세팅하는 전략으로 변경
- 토큰 추출기에서 닉네임을 검증 -> 닉네임은 Nullable하기 떄문에 닉네임 검증은 제거

4. CORS 정책 추가
