### PR TITLE
[FEATURE] Jwt 로그아웃 로직 작성

### DIFF
--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/exception/UserNotFoundException.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/exception/UserNotFoundException.java
@@ -1,6 +1,5 @@
 package io.github.cokelee777.springsecurityjwtauth.exception;
 
-// TODO: 인가 과정에서 발생한 오류에 대한 것이기 때문에 후에 예외처리 구현 시 수정 필요
 public class UserNotFoundException extends IllegalArgumentException {
 
     public UserNotFoundException(String s) {

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.security.web.authentication.logout.LogoutFilter;
 public class JwtSecurityConfiguration {
 
     private static final String[] PUBLIC_END_POINT = {"/", "/users/sign-in", "/users/sign-up"};
+    private static final String LOGOUT_END_POINT = "/users/sign-out";
 
     private final PrincipalUserDetailsService principalUserDetailsService;
     private final PasswordEncoder passwordEncoder;
@@ -63,7 +64,7 @@ public class JwtSecurityConfiguration {
 
         // 로그아웃 설정
         http.logout()
-                .logoutUrl("/users/logout")
+                .logoutUrl(LOGOUT_END_POINT)
                 .addLogoutHandler(new JwtLogoutHandler())
                 .logoutSuccessHandler(new JwtLogoutSuccessHandler());
 

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/config/JwtSecurityConfiguration.java
@@ -5,6 +5,8 @@ import io.github.cokelee777.springsecurityjwtauth.security.filter.JwtAuthorizati
 import io.github.cokelee777.springsecurityjwtauth.security.filter.JwtMemoryAuthorizationFilter;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.CustomAccessDeniedHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.failure.CustomAuthenticationFailureHandler;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.logout.JwtLogoutHandler;
+import io.github.cokelee777.springsecurityjwtauth.security.handler.logout.JwtLogoutSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.handler.success.CustomAuthenticationSuccessHandler;
 import io.github.cokelee777.springsecurityjwtauth.security.provider.JwtAuthenticationProvider;
 import io.github.cokelee777.springsecurityjwtauth.security.service.PrincipalUserDetailsService;
@@ -58,6 +60,12 @@ public class JwtSecurityConfiguration {
             .formLogin().disable()
             .httpBasic().disable()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        // 로그아웃 설정
+        http.logout()
+                .logoutUrl("/users/logout")
+                .addLogoutHandler(new JwtLogoutHandler())
+                .logoutSuccessHandler(new JwtLogoutSuccessHandler());
 
         // 인가 API
         http.authorizeHttpRequests()

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutHandler.java
@@ -8,19 +8,23 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 
 public class JwtLogoutHandler implements LogoutHandler {
-    private final static Cookie COOKIE = new Cookie("Authorization", null);
+    private final static Cookie EXPIRED_COOKIE = new Cookie("Authorization", null);
 
     public JwtLogoutHandler() {
-        COOKIE.setMaxAge(0);
-        COOKIE.setHttpOnly(true);
+        setExpiredCookie();
     }
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         // 쿠키 삭제
-        response.addCookie(COOKIE);
-
+        response.addCookie(EXPIRED_COOKIE);
         // SecurityContextHolder clear
         SecurityContextHolder.clearContext();
+    }
+
+    private void setExpiredCookie() {
+        EXPIRED_COOKIE.setMaxAge(0);
+        EXPIRED_COOKIE.setHttpOnly(true);
+        EXPIRED_COOKIE.setPath("/");
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutHandler.java
@@ -8,14 +8,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 
 public class JwtLogoutHandler implements LogoutHandler {
+    private final static Cookie COOKIE = new Cookie("Authorization", null);
+
+    public JwtLogoutHandler() {
+        COOKIE.setMaxAge(0);
+        COOKIE.setHttpOnly(true);
+    }
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         // 쿠키 삭제
-        Cookie cookie = new Cookie("Authorization", null);
-        cookie.setMaxAge(0);
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
+        response.addCookie(COOKIE);
 
         // SecurityContextHolder clear
         SecurityContextHolder.clearContext();

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutHandler.java
@@ -1,0 +1,23 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.logout;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+public class JwtLogoutHandler implements LogoutHandler {
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        // 쿠키 삭제
+        Cookie cookie = new Cookie("Authorization", null);
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+
+        // SecurityContextHolder clear
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutSuccessHandler.java
@@ -1,0 +1,32 @@
+package io.github.cokelee777.springsecurityjwtauth.security.handler.logout;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cokelee777.springsecurityjwtauth.dto.common.SuccessResponseBody;
+import io.github.cokelee777.springsecurityjwtauth.utils.DefaultHttpMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final static String LOGOUT_SUCCESS_MESSAGE = "로그아웃 성공, ";
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+        response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+        objectMapper.writeValue(response.getWriter(), new SuccessResponseBody<>(
+                HttpStatus.MOVED_PERMANENTLY.getReasonPhrase(),
+                LOGOUT_SUCCESS_MESSAGE + String.format(DefaultHttpMessage.MOVED_PERMANENTLY, "/users/sign-in"),
+                null));
+    }
+}

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/logout/JwtLogoutSuccessHandler.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
 public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final static String LOGOUT_SUCCESS_MESSAGE = "로그아웃 성공, ";
+    private final static String LOGOUT_REDIRECT_END_POINT = "/users/sign-in";
 
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
@@ -24,9 +24,10 @@ public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
         response.setStatus(HttpStatus.MOVED_PERMANENTLY.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+
         objectMapper.writeValue(response.getWriter(), new SuccessResponseBody<>(
                 HttpStatus.MOVED_PERMANENTLY.getReasonPhrase(),
-                LOGOUT_SUCCESS_MESSAGE + String.format(DefaultHttpMessage.MOVED_PERMANENTLY, "/users/sign-in"),
+                String.format(DefaultHttpMessage.MOVED_PERMANENTLY, LOGOUT_REDIRECT_END_POINT),
                 null));
     }
 }

--- a/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
+++ b/src/main/java/io/github/cokelee777/springsecurityjwtauth/security/handler/success/JwtMemoryAuthenticationSuccessHandler.java
@@ -63,6 +63,7 @@ public class JwtMemoryAuthenticationSuccessHandler implements JwtAuthenticationS
         Cookie cookie = new Cookie("Authorization", encodedValue);
         cookie.setMaxAge(COOKIE_EXPIRED_SECOND);
         cookie.setHttpOnly(true);
+        cookie.setPath("/");
         // setSecure을 true로 할 시 HTTPS 에서만 접근 가능하기 때문
 //        cookie.setSecure(true);
         response.addCookie(cookie);


### PR DESCRIPTION
1. 로그아웃 handler 구현

로그아웃 과정에서 쿠키 내에 있는 토큰을 삭제하고 SecurityContext 정보 초기화 하여야 하기 때문에 해당 로직 구현.
access 토큰은 redis 를 사용하지 않기 때문에 클라이언트가 헤더에서 직접 삭제하도록 구현.

2. 로그아웃 성공 handler 구현

로그아웃 성공 시 재로그인을 위해 로그인 화면으로 이동할 수 있도록 redirect를 요청하는 응답을 보냄

3. security configuration에 로그아웃 설정 추가

deleteCookies 메서드 -> default 옵션이 달라서 현재 프로젝트의 토큰 속성과 달라 토큰이 삭제되지 않아서 삭제 후 직접 구현
(심지어 속성 설정이 불가능함)
clearAuthentication 메서드 -> default가 true이기 때문에 삭제

4. TODO 주석 삭제
#24 
- USERNOTFOUND 예외가 다른 곳에서도 사용되는 메서드에서 던져지기 때문에 공통적으로 사용되는 예외를 상속 받도록 결정

5. code refactoring

삭제용 쿠키 객체 싱글톤 형식으로 변경